### PR TITLE
feat: user pvc to store the cached helm repo charts

### DIFF
--- a/charts/kubebb-core/Chart.yaml
+++ b/charts/kubebb-core/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kubebb-core
 description: Kubebb Core provides core implementations on Component Lifecycle Management.Our design and development follows operator pattern which extends kubernetes APIs.
 type: application
-version: v0.1.0
+version: v0.1.1
 icon: https://avatars.githubusercontent.com/u/85277200
 keywords:
   - repository

--- a/charts/kubebb-core/templates/deploy.yaml
+++ b/charts/kubebb-core/templates/deploy.yaml
@@ -24,12 +24,26 @@ spec:
         # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
         # seccompProfile:
         #   type: RuntimeDefault
+      volumes:
+      - name: helm
+        persistentVolumeClaim:
+          claimName: {{ .Release.Name }}
       containers:
       - command:
         - /manager
         image: {{ .Values.deployment.image }}
         imagePullPolicy: {{ .Values.deployment.imagePullPolicy }}
+        env:
+        - name: HELM_CACHE_HOME
+          value: /opt/helm/cache/helm
+        - name: HELM_CONFIG_HOME
+          value: /opt/helm/config/helm
+        - name: HELM_DATA_HOME
+          value: /opt/helm/data/helm
         name: manager
+        volumeMounts:
+        - mountPath: /opt/helm
+          name: helm
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/charts/kubebb-core/templates/pvc.yaml
+++ b/charts/kubebb-core/templates/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  storageClassName: {{ .Values.pvc.storageClassName }}
+  accessModes: {{ toYaml .Values.pvc.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.pvc.storageSize }}

--- a/charts/kubebb-core/values.yaml
+++ b/charts/kubebb-core/values.yaml
@@ -8,3 +8,8 @@ deployment:
     requests:
       cpu: 10m
       memory: 64Mi
+pvc:
+  storageClassName: standard
+  accessModes:
+    - ReadWriteOnce
+  storageSize: 5Gi


### PR DESCRIPTION

Fix: https://github.com/kubebb/core/issues/76
```shell
/opt/helm $ pwd
/opt/helm
/opt/helm $ ls
caches  config
/opt/helm $ ls caches/helm/repository/
kubebb-system.kubebb-charts.txt  kubebb-system.kubebb-index.yaml
/opt/helm $ ls config/helm/
repositories.lock  repositories.yaml
```