### PR TITLE
feat: add labels to indicate official components in the repository

### DIFF
--- a/repos/repository_kubebb.yaml
+++ b/repos/repository_kubebb.yaml
@@ -3,6 +3,8 @@ kind: Repository
 metadata:
   name: kubebb
   namespace: kubebb-system
+  labels:
+    kubebb.repository.source: official
 spec:
   url: https://kubebb.github.io/components
   pullStategy:


### PR DESCRIPTION
Fix [#229](https://github.com/kubebb/core/issues/229)