### PR TITLE
Update minio user/pass

### DIFF
--- a/.github/workflows/lint_test.yaml
+++ b/.github/workflows/lint_test.yaml
@@ -34,7 +34,7 @@ jobs:
       # https://github.com/helm/chart-testing-action
       - name: Run chart-testing (lint)
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct lint --target-branch ${{ github.event.repository.default_branch }}
+        run: ct lint --validate-maintainers=false --target-branch ${{ github.event.repository.default_branch }}
 
       # FIXME: once component dependency much more clear, we can enable this
       # - name: Create kind cluster

--- a/charts/minio/Chart.yaml
+++ b/charts/minio/Chart.yaml
@@ -4,15 +4,15 @@ description: Multi-Cloud Object Storage
 home: https://min.io
 icon: https://min.io/resources/img/logo/MINIO_wordmark.png
 keywords:
-- minio
-- storage
-- object-storage
-- s3
-- cluster
+  - minio
+  - storage
+  - object-storage
+  - s3
+  - cluster
 maintainers:
-- email: dev@minio.io
-  name: MinIO, Inc
+  - email: dev@minio.io
+    name: MinIO, Inc
 name: minio
 sources:
-- https://github.com/minio/minio
-version: 5.0.7
+  - https://github.com/minio/minio
+version: 5.0.8

--- a/charts/minio/README.md
+++ b/charts/minio/README.md
@@ -1,260 +1,51 @@
-# MinIO Helm Chart
+# MinIO Helm Chart(KubeBB optimized)
 
-[![Slack](https://slack.min.io/slack?type=svg)](https://slack.min.io) [![license](https://img.shields.io/badge/license-AGPL%20V3-blue)](https://github.com/minio/minio/blob/master/LICENSE)
+This chart bootstraps a Minio deployment on a Kubernetes cluster using the Helm package manager. This chart comes from [minio charts](https://github.com/minio/minio/tree/master/helm/minio),but optimized for kubebb!
 
-MinIO is a High Performance Object Storage released under GNU Affero General Public License v3.0. It is API compatible with Amazon S3 cloud storage service. Use MinIO to build high performance infrastructure for machine learning, analytics and application data workloads.
+## Usage
 
-For more detailed documentation please visit [here](https://min.io/docs/minio/linux/index.html)
+### With Helm
 
-## Introduction
-
-This chart bootstraps MinIO Cluster on [Kubernetes](http://kubernetes.io) using the [Helm](https://helm.sh) package manager.
-
-## Prerequisites
-
-- Helm cli with Kubernetes cluster configured.
-- PV provisioner support in the underlying infrastructure. (We recommend using <https://github.com/minio/direct-csi>)
-- Use Kubernetes version v1.19 and later for best experience.
-
-## Configure MinIO Helm repo
-
-```bash
-helm repo add minio https://charts.min.io/
+```shell
+    helm repo add kubebb https://kubebb.github.io/components
+    helm install minio kubebb/minio
 ```
 
-### Installing the Chart
+### With Kubebb
 
-Install this chart using:
+1. Prerequisites
 
-```bash
-helm install --namespace minio --set rootUser=rootuser,rootPassword=rootpass123 --generate-name minio/minio
+Install the [kubebb core](https://kubebb.github.io/website/docs/quick-start/core_quickstart).
+
+2. Add repository `kubebb`
+
+```shell
+    kubectl apply -f https://raw.githubusercontent.com/kubebb/components/main/repos/repository_kubebb.yaml
 ```
 
-The command deploys MinIO on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+3. Plan a `Minio`
 
-### Installing the Chart (toy-setup)
+> For more details on minio configuration,see [link](./README_origin.md)
 
-Minimal toy setup for testing purposes can be deployed using:
+For example:
 
-```bash
-helm install --set resources.requests.memory=512Mi --set replicas=1 --set persistence.enabled=false --set mode=standalone --set rootUser=rootuser,rootPassword=rootpass123 --generate-name minio/minio
+```shell
+apiVersion: core.kubebb.k8s.com.cn/v1alpha1
+kind: ComponentPlan
+metadata:
+  name: my-minio
+  namespace: default
+spec:
+  approved: true
+  name: my-minio # similar to helm release name
+  version: 5.0.7
+  component:
+    name: kubebb.minio
+    namespace: kubebb-system
+  override:
+    set:
+      - rootUser=admin
+      - rootPassword=Passw0rd!
 ```
 
-### Upgrading the Chart
-
-You can use Helm to update MinIO version in a live release. Assuming your release is named as `my-release`, get the values using the command:
-
-```bash
-helm get values my-release > old_values.yaml
-```
-
-Then change the field `image.tag` in `old_values.yaml` file with MinIO image tag you want to use. Now update the chart using
-
-```bash
-helm upgrade -f old_values.yaml my-release minio/minio
-```
-
-Default upgrade strategies are specified in the `values.yaml` file. Update these fields if you'd like to use a different strategy.
-
-### Configuration
-
-Refer the [Values file](./values.yaml) for all the possible config fields.
-
-You can specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
-
-```bash
-helm install --name my-release --set persistence.size=1Ti minio/minio
-```
-
-The above command deploys MinIO server with a 1Ti backing persistent volume.
-
-Alternately, you can provide a YAML file that specifies parameter values while installing the chart. For example,
-
-```bash
-helm install --name my-release -f values.yaml minio/minio
-```
-
-### Persistence
-
-This chart provisions a PersistentVolumeClaim and mounts corresponding persistent volume to default location `/export`. You'll need physical storage available in the Kubernetes cluster for this to work. If you'd rather use `emptyDir`, disable PersistentVolumeClaim by:
-
-```bash
-helm install --set persistence.enabled=false minio/minio
-```
-
-> *"An emptyDir volume is first created when a Pod is assigned to a Node, and exists as long as that Pod is running on that node. When a Pod is removed from a node for any reason, the data in the emptyDir is deleted forever."*
-
-### Existing PersistentVolumeClaim
-
-If a Persistent Volume Claim already exists, specify it during installation.
-
-1. Create the PersistentVolume
-2. Create the PersistentVolumeClaim
-3. Install the chart
-
-```bash
-helm install --set persistence.existingClaim=PVC_NAME minio/minio
-```
-
-### NetworkPolicy
-
-To enable network policy for MinIO,
-install [a networking plugin that implements the Kubernetes
-NetworkPolicy spec](https://kubernetes.io/docs/tasks/administer-cluster/declare-network-policy#before-you-begin),
-and set `networkPolicy.enabled` to `true`.
-
-For Kubernetes v1.5 & v1.6, you must also turn on NetworkPolicy by setting
-the DefaultDeny namespace annotation. Note: this will enforce policy for *all* pods in the namespace:
-
-```
-kubectl annotate namespace default "net.beta.kubernetes.io/network-policy={\"ingress\":{\"isolation\":\"DefaultDeny\"}}"
-```
-
-With NetworkPolicy enabled, traffic will be limited to just port 9000.
-
-For more precise policy, set `networkPolicy.allowExternal=true`. This will
-only allow pods with the generated client label to connect to MinIO.
-This label will be displayed in the output of a successful install.
-
-### Existing secret
-
-Instead of having this chart create the secret for you, you can supply a preexisting secret, much
-like an existing PersistentVolumeClaim.
-
-First, create the secret:
-
-```bash
-kubectl create secret generic my-minio-secret --from-literal=rootUser=foobarbaz --from-literal=rootPassword=foobarbazqux
-```
-
-Then install the chart, specifying that you want to use an existing secret:
-
-```bash
-helm install --set existingSecret=my-minio-secret minio/minio
-```
-
-The following fields are expected in the secret:
-
-| .data.\<key\> in Secret | Corresponding variable | Description    | Required |
-|:------------------------|:-----------------------|:---------------|:---------|
-| `rootUser`              | `rootUser`             | Root user.     | yes      |
-| `rootPassword`          | `rootPassword`         | Root password. | yes      |
-
-All corresponding variables will be ignored in values file.
-
-### Configure TLS
-
-To enable TLS for MinIO containers, acquire TLS certificates from a CA or create self-signed certificates. While creating / acquiring certificates ensure the corresponding domain names are set as per the standard [DNS naming conventions](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-identity) in a Kubernetes StatefulSet (for a distributed MinIO setup). Then create a secret using
-
-```bash
-kubectl create secret generic tls-ssl-minio --from-file=path/to/private.key --from-file=path/to/public.crt
-```
-
-Then install the chart, specifying that you want to use the TLS secret:
-
-```bash
-helm install --set tls.enabled=true,tls.certSecret=tls-ssl-minio minio/minio
-```
-
-### Installing certificates from third party CAs
-
-MinIO can connect to other servers, including MinIO nodes or other server types such as NATs and Redis. If these servers use certificates that were not registered with a known CA, add trust for these certificates to MinIO Server by bundling these certificates into a Kubernetes secret and providing it to Helm via the `trustedCertsSecret` value. If `.Values.tls.enabled` is `true` and you're installing certificates for third party CAs, remember to include MinIO's own certificate with key `public.crt`, if it also needs to be trusted.
-
-For instance, given that TLS is enabled and you need to add trust for MinIO's own CA and for the CA of a Keycloak server, a Kubernetes secret can be created from the certificate files using `kubectl`:
-
-```
-kubectl -n minio create secret generic minio-trusted-certs --from-file=public.crt --from-file=keycloak.crt
-```
-
-If TLS is not enabled, you would need only the third party CA:
-
-```
-kubectl -n minio create secret generic minio-trusted-certs --from-file=keycloak.crt
-```
-
-The name of the generated secret can then be passed to Helm using a values file or the `--set` parameter:
-
-```
-trustedCertsSecret: "minio-trusted-certs"
-
-or
-
---set trustedCertsSecret=minio-trusted-certs
-```
-
-### Create buckets after install
-
-Install the chart, specifying the buckets you want to create after install:
-
-```bash
-helm install --set buckets[0].name=bucket1,buckets[0].policy=none,buckets[0].purge=false minio/minio
-```
-
-Description of the configuration parameters used above -
-
-- `buckets[].name` - name of the bucket to create, must be a string with length > 0
-- `buckets[].policy` - can be one of none|download|upload|public
-- `buckets[].purge` - purge if bucket exists already
-
-### Create policies after install
-
-Install the chart, specifying the policies you want to create after install:
-
-```bash
-helm install --set policies[0].name=mypolicy,policies[0].statements[0].resources[0]='arn:aws:s3:::bucket1',policies[0].statements[0].actions[0]='s3:ListBucket',policies[0].statements[0].actions[1]='s3:GetObject' minio/minio
-```
-
-Description of the configuration parameters used above -
-
-- `policies[].name` - name of the policy to create, must be a string with length > 0
-- `policies[].statements[]` - list of statements, includes actions and resources
-- `policies[].statements[].resources[]` - list of resources that applies the statement
-- `policies[].statements[].actions[]` - list of actions granted
-
-### Create user after install
-
-Install the chart, specifying the users you want to create after install:
-
-```bash
-helm install --set users[0].accessKey=accessKey,users[0].secretKey=secretKey,users[0].policy=none,users[1].accessKey=accessKey2,users[1].secretRef=existingSecret,users[1].secretKey=password,users[1].policy=none minio/minio
-```
-
-Description of the configuration parameters used above -
-
-- `users[].accessKey` - accessKey of user
-- `users[].secretKey` - secretKey of usersecretRef
-- `users[].existingSecret` - secret name that contains the secretKey of user
-- `users[].existingSecretKey` - data key in existingSecret secret containing the secretKey
-- `users[].policy` - name of the policy to assign to user
-
-### Create service account after install
-
-Install the chart, specifying the service accounts you want to create after install:
-
-```bash
-helm install --set svcaccts[0].accessKey=accessKey,svcaccts[0].secretKey=secretKey,svcaccts[0].user=parentUser,svcaccts[1].accessKey=accessKey2,svcaccts[1].secretRef=existingSecret,svcaccts[1].secretKey=password,svcaccts[1].user=parentUser2 minio/minio
-```
-
-Description of the configuration parameters used above -
-
-- `svcaccts[].accessKey` - accessKey of service account
-- `svcaccts[].secretKey` - secretKey of svcacctsecretRef
-- `svcaccts[].existingSecret` - secret name that contains the secretKey of service account
-- `svcaccts[].existingSecretKey` - data key in existingSecret secret containing the secretKey
-- `svcaccts[].user` - name of the parent user to assign to service account
-
-## Uninstalling the Chart
-
-Assuming your release is named as `my-release`, delete it using the command:
-
-```bash
-helm delete my-release
-```
-
-or
-
-```bash
-helm uninstall my-release
-```
-
-The command removes all the Kubernetes components associated with the chart and deletes the release.
+NOTE: After applied this `ComponentPlan`,you will get a minio cluster with 3 instances.The default username and password will be `admin/Passw0rd!`

--- a/charts/minio/README_origin.md
+++ b/charts/minio/README_origin.md
@@ -1,0 +1,260 @@
+# MinIO Helm Chart
+
+[![Slack](https://slack.min.io/slack?type=svg)](https://slack.min.io) [![license](https://img.shields.io/badge/license-AGPL%20V3-blue)](https://github.com/minio/minio/blob/master/LICENSE)
+
+MinIO is a High Performance Object Storage released under GNU Affero General Public License v3.0. It is API compatible with Amazon S3 cloud storage service. Use MinIO to build high performance infrastructure for machine learning, analytics and application data workloads.
+
+For more detailed documentation please visit [here](https://min.io/docs/minio/linux/index.html)
+
+## Introduction
+
+This chart bootstraps MinIO Cluster on [Kubernetes](http://kubernetes.io) using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+- Helm cli with Kubernetes cluster configured.
+- PV provisioner support in the underlying infrastructure. (We recommend using <https://github.com/minio/direct-csi>)
+- Use Kubernetes version v1.19 and later for best experience.
+
+## Configure MinIO Helm repo
+
+```bash
+helm repo add minio https://charts.min.io/
+```
+
+### Installing the Chart
+
+Install this chart using:
+
+```bash
+helm install --namespace minio --set rootUser=rootuser,rootPassword=rootpass123 --generate-name minio/minio
+```
+
+The command deploys MinIO on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+### Installing the Chart (toy-setup)
+
+Minimal toy setup for testing purposes can be deployed using:
+
+```bash
+helm install --set resources.requests.memory=512Mi --set replicas=1 --set persistence.enabled=false --set mode=standalone --set rootUser=rootuser,rootPassword=rootpass123 --generate-name minio/minio
+```
+
+### Upgrading the Chart
+
+You can use Helm to update MinIO version in a live release. Assuming your release is named as `my-release`, get the values using the command:
+
+```bash
+helm get values my-release > old_values.yaml
+```
+
+Then change the field `image.tag` in `old_values.yaml` file with MinIO image tag you want to use. Now update the chart using
+
+```bash
+helm upgrade -f old_values.yaml my-release minio/minio
+```
+
+Default upgrade strategies are specified in the `values.yaml` file. Update these fields if you'd like to use a different strategy.
+
+### Configuration
+
+Refer the [Values file](./values.yaml) for all the possible config fields.
+
+You can specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+helm install --name my-release --set persistence.size=1Ti minio/minio
+```
+
+The above command deploys MinIO server with a 1Ti backing persistent volume.
+
+Alternately, you can provide a YAML file that specifies parameter values while installing the chart. For example,
+
+```bash
+helm install --name my-release -f values.yaml minio/minio
+```
+
+### Persistence
+
+This chart provisions a PersistentVolumeClaim and mounts corresponding persistent volume to default location `/export`. You'll need physical storage available in the Kubernetes cluster for this to work. If you'd rather use `emptyDir`, disable PersistentVolumeClaim by:
+
+```bash
+helm install --set persistence.enabled=false minio/minio
+```
+
+> *"An emptyDir volume is first created when a Pod is assigned to a Node, and exists as long as that Pod is running on that node. When a Pod is removed from a node for any reason, the data in the emptyDir is deleted forever."*
+
+### Existing PersistentVolumeClaim
+
+If a Persistent Volume Claim already exists, specify it during installation.
+
+1. Create the PersistentVolume
+2. Create the PersistentVolumeClaim
+3. Install the chart
+
+```bash
+helm install --set persistence.existingClaim=PVC_NAME minio/minio
+```
+
+### NetworkPolicy
+
+To enable network policy for MinIO,
+install [a networking plugin that implements the Kubernetes
+NetworkPolicy spec](https://kubernetes.io/docs/tasks/administer-cluster/declare-network-policy#before-you-begin),
+and set `networkPolicy.enabled` to `true`.
+
+For Kubernetes v1.5 & v1.6, you must also turn on NetworkPolicy by setting
+the DefaultDeny namespace annotation. Note: this will enforce policy for *all* pods in the namespace:
+
+```
+kubectl annotate namespace default "net.beta.kubernetes.io/network-policy={\"ingress\":{\"isolation\":\"DefaultDeny\"}}"
+```
+
+With NetworkPolicy enabled, traffic will be limited to just port 9000.
+
+For more precise policy, set `networkPolicy.allowExternal=true`. This will
+only allow pods with the generated client label to connect to MinIO.
+This label will be displayed in the output of a successful install.
+
+### Existing secret
+
+Instead of having this chart create the secret for you, you can supply a preexisting secret, much
+like an existing PersistentVolumeClaim.
+
+First, create the secret:
+
+```bash
+kubectl create secret generic my-minio-secret --from-literal=rootUser=foobarbaz --from-literal=rootPassword=foobarbazqux
+```
+
+Then install the chart, specifying that you want to use an existing secret:
+
+```bash
+helm install --set existingSecret=my-minio-secret minio/minio
+```
+
+The following fields are expected in the secret:
+
+| .data.\<key\> in Secret | Corresponding variable | Description    | Required |
+|:------------------------|:-----------------------|:---------------|:---------|
+| `rootUser`              | `rootUser`             | Root user.     | yes      |
+| `rootPassword`          | `rootPassword`         | Root password. | yes      |
+
+All corresponding variables will be ignored in values file.
+
+### Configure TLS
+
+To enable TLS for MinIO containers, acquire TLS certificates from a CA or create self-signed certificates. While creating / acquiring certificates ensure the corresponding domain names are set as per the standard [DNS naming conventions](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-identity) in a Kubernetes StatefulSet (for a distributed MinIO setup). Then create a secret using
+
+```bash
+kubectl create secret generic tls-ssl-minio --from-file=path/to/private.key --from-file=path/to/public.crt
+```
+
+Then install the chart, specifying that you want to use the TLS secret:
+
+```bash
+helm install --set tls.enabled=true,tls.certSecret=tls-ssl-minio minio/minio
+```
+
+### Installing certificates from third party CAs
+
+MinIO can connect to other servers, including MinIO nodes or other server types such as NATs and Redis. If these servers use certificates that were not registered with a known CA, add trust for these certificates to MinIO Server by bundling these certificates into a Kubernetes secret and providing it to Helm via the `trustedCertsSecret` value. If `.Values.tls.enabled` is `true` and you're installing certificates for third party CAs, remember to include MinIO's own certificate with key `public.crt`, if it also needs to be trusted.
+
+For instance, given that TLS is enabled and you need to add trust for MinIO's own CA and for the CA of a Keycloak server, a Kubernetes secret can be created from the certificate files using `kubectl`:
+
+```
+kubectl -n minio create secret generic minio-trusted-certs --from-file=public.crt --from-file=keycloak.crt
+```
+
+If TLS is not enabled, you would need only the third party CA:
+
+```
+kubectl -n minio create secret generic minio-trusted-certs --from-file=keycloak.crt
+```
+
+The name of the generated secret can then be passed to Helm using a values file or the `--set` parameter:
+
+```
+trustedCertsSecret: "minio-trusted-certs"
+
+or
+
+--set trustedCertsSecret=minio-trusted-certs
+```
+
+### Create buckets after install
+
+Install the chart, specifying the buckets you want to create after install:
+
+```bash
+helm install --set buckets[0].name=bucket1,buckets[0].policy=none,buckets[0].purge=false minio/minio
+```
+
+Description of the configuration parameters used above -
+
+- `buckets[].name` - name of the bucket to create, must be a string with length > 0
+- `buckets[].policy` - can be one of none|download|upload|public
+- `buckets[].purge` - purge if bucket exists already
+
+### Create policies after install
+
+Install the chart, specifying the policies you want to create after install:
+
+```bash
+helm install --set policies[0].name=mypolicy,policies[0].statements[0].resources[0]='arn:aws:s3:::bucket1',policies[0].statements[0].actions[0]='s3:ListBucket',policies[0].statements[0].actions[1]='s3:GetObject' minio/minio
+```
+
+Description of the configuration parameters used above -
+
+- `policies[].name` - name of the policy to create, must be a string with length > 0
+- `policies[].statements[]` - list of statements, includes actions and resources
+- `policies[].statements[].resources[]` - list of resources that applies the statement
+- `policies[].statements[].actions[]` - list of actions granted
+
+### Create user after install
+
+Install the chart, specifying the users you want to create after install:
+
+```bash
+helm install --set users[0].accessKey=accessKey,users[0].secretKey=secretKey,users[0].policy=none,users[1].accessKey=accessKey2,users[1].secretRef=existingSecret,users[1].secretKey=password,users[1].policy=none minio/minio
+```
+
+Description of the configuration parameters used above -
+
+- `users[].accessKey` - accessKey of user
+- `users[].secretKey` - secretKey of usersecretRef
+- `users[].existingSecret` - secret name that contains the secretKey of user
+- `users[].existingSecretKey` - data key in existingSecret secret containing the secretKey
+- `users[].policy` - name of the policy to assign to user
+
+### Create service account after install
+
+Install the chart, specifying the service accounts you want to create after install:
+
+```bash
+helm install --set svcaccts[0].accessKey=accessKey,svcaccts[0].secretKey=secretKey,svcaccts[0].user=parentUser,svcaccts[1].accessKey=accessKey2,svcaccts[1].secretRef=existingSecret,svcaccts[1].secretKey=password,svcaccts[1].user=parentUser2 minio/minio
+```
+
+Description of the configuration parameters used above -
+
+- `svcaccts[].accessKey` - accessKey of service account
+- `svcaccts[].secretKey` - secretKey of svcacctsecretRef
+- `svcaccts[].existingSecret` - secret name that contains the secretKey of service account
+- `svcaccts[].existingSecretKey` - data key in existingSecret secret containing the secretKey
+- `svcaccts[].user` - name of the parent user to assign to service account
+
+## Uninstalling the Chart
+
+Assuming your release is named as `my-release`, delete it using the command:
+
+```bash
+helm delete my-release
+```
+
+or
+
+```bash
+helm uninstall my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.

--- a/charts/minio/values.yaml
+++ b/charts/minio/values.yaml
@@ -29,7 +29,7 @@ mcImage:
   pullPolicy: IfNotPresent
 
 ## minio mode, i.e. standalone or distributed
-mode: distributed ## other supported values are "standalone"
+mode: distributed
 
 ## Additional labels to include with deployment or statefulset
 additionalLabels: {}
@@ -182,10 +182,12 @@ service:
 ingress:
   enabled: false
   ingressClassName: "portal-ingress"
-  labels: {}
+  labels:
+    {}
     # node-role.kubernetes.io/ingress: platform
 
-  annotations: {}
+  annotations:
+    {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
     # kubernetes.io/ingress.allow-http: "false"
@@ -210,10 +212,12 @@ consoleService:
 consoleIngress:
   enabled: true
   ingressClassName: "portal-ingress"
-  labels: {}
+  labels:
+    {}
     # node-role.kubernetes.io/ingress: platform
 
-  annotations: {}
+  annotations:
+    {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
     # kubernetes.io/ingress.allow-http: "false"
@@ -270,7 +274,7 @@ policies:
 # - name: custom
 #   statements:
 #     - resources:
-#         - 'arn:aws:s3:::bestchains'
+#         - 'arn:aws:s3:::kubebb'
 #       actions:
 #         - "s3:ListBucket"
 #         - "s3:GetBucketLocation"
@@ -279,7 +283,7 @@ policies:
 #         AWS:
 #         - "*"
 #     - resources:
-#         - 'arn:aws:s3:::bestchains/*'
+#         - 'arn:aws:s3:::kubebb/*'
 #       actions:
 #         - "s3:GetObject"
 #       effect: 'Allow'
@@ -329,17 +333,18 @@ makePolicyJob:
 
 ## List of users to be created after minio install
 ##
-users: []
+users:
+  []
   ## Username, password and policy to be assigned to the user
   ## Default policies are [readonly|readwrite|writeonly|consoleAdmin|diagnostics]
   ## Add new policies as explained here https://min.io/docs/minio/kubernetes/upstream/administration/identity-access-management.html#access-management
   ## NOTE: this will fail if LDAP is enabled in your MinIO deployment
   ## make sure to disable this if you are using LDAP.
-  #- accessKey: q18aRFqWOAX7pEin
+  # - accessKey: q18aRFqWOAX7pEin
   #  secretKey: nCbZIP6q4s8KtQpL7n8CD2N88H6XABGf
   #  policy: readwrite
   # Or you can refer to specific secret
-  #- accessKey: externalSecret
+  # - accessKey: externalSecret
   #  existingSecret: my-secret
   #  existingSecretKey: password
   #  policy: readonly
@@ -359,30 +364,30 @@ makeUserJob:
 ## List of service accounts to be created after minio install
 ##
 # svcaccts:
-  ## accessKey, secretKey and parent user to be assigned to the service accounts
-  ## Add new service accounts as explained here https://min.io/docs/minio/kubernetes/upstream/administration/identity-access-management/minio-user-management.html#service-accounts
-  # - accessKey: console-svcacct
-  #   secretKey: console123
-  #   user: console
-  ## Or you can refer to specific secret
-  # - accessKey: externalSecret
-  #   existingSecret: my-secret
-  #   existingSecretKey: password
-  #   user: console
-  ## You also can pass custom policy
-  # - accessKey: console-svcacct
-  #   secretKey: console123
-  #   user: console
-  #   policy:
-  #     statements:
-  #       - resources:
-  #           - 'arn:aws:s3:::example*/*'
-  #         actions:
-  #           - "s3:AbortMultipartUpload"
-  #           - "s3:GetObject"
-  #           - "s3:DeleteObject"
-  #           - "s3:PutObject"
-  #           - "s3:ListMultipartUploadParts"
+## accessKey, secretKey and parent user to be assigned to the service accounts
+## Add new service accounts as explained here https://min.io/docs/minio/kubernetes/upstream/administration/identity-access-management/minio-user-management.html#service-accounts
+# - accessKey: console-svcacct
+#   secretKey: console123
+#   user: console
+## Or you can refer to specific secret
+# - accessKey: externalSecret
+#   existingSecret: my-secret
+#   existingSecretKey: password
+#   user: console
+## You also can pass custom policy
+# - accessKey: console-svcacct
+#   secretKey: console123
+#   user: console
+#   policy:
+#     statements:
+#       - resources:
+#           - 'arn:aws:s3:::example*/*'
+#         actions:
+#           - "s3:AbortMultipartUpload"
+#           - "s3:GetObject"
+#           - "s3:DeleteObject"
+#           - "s3:PutObject"
+#           - "s3:ListMultipartUploadParts"
 
 makeServiceAccountJob:
   securityContext:
@@ -398,41 +403,41 @@ makeServiceAccountJob:
 ## List of buckets to be created after minio install
 ##
 buckets:
-     # Name of the bucket
-   - name: bestchains
-     # Policy to be set on the
-     # bucket [none|download|upload|public|custom]
-     # if set to custom, customPolicy must be set.
-     policy: "custom"
-     # Purge if bucket exists already
-     purge: false
-     # set versioning for
-     # bucket [true|false]
-     versioning: false
-     # set objectlocking for
-     # bucket [true|false] NOTE: versioning is enabled by default if you use locking
-     objectlocking: false
-     # set custom policy
-     customPolicy:
-       Version: '2012-10-17'
-       Statement:
-         - Effect: Allow
-           Principal:
-             AWS:
-               - "*"
-           Action:
-             - s3:ListBucket
-             - s3:GetBucketLocation
-           Resource:
-             - arn:aws:s3:::bestchains
-         - Effect: Allow
-           Principal:
-             AWS:
-               - "*"
-           Action:
-             - s3:GetObject
-           Resource:
-             - arn:aws:s3:::bestchains/*
+  # Name of the bucket
+  - name: kubebb
+    # Policy to be set on the
+    # bucket [none|download|upload|public|custom]
+    # if set to custom, customPolicy must be set.
+    policy: "custom"
+    # Purge if bucket exists already
+    purge: false
+    # set versioning for
+    # bucket [true|false]
+    versioning: false
+    # set objectlocking for
+    # bucket [true|false] NOTE: versioning is enabled by default if you use locking
+    objectlocking: false
+    # set custom policy
+    customPolicy:
+      Version: "2012-10-17"
+      Statement:
+        - Effect: Allow
+          Principal:
+            AWS:
+              - "*"
+          Action:
+            - s3:ListBucket
+            - s3:GetBucketLocation
+          Resource:
+            - arn:aws:s3:::kubebb
+        - Effect: Allow
+          Principal:
+            AWS:
+              - "*"
+          Action:
+            - s3:GetObject
+          Resource:
+            - arn:aws:s3:::kubebb/*
 
 ## Additional Annotations for the Kubernetes Job makeBucketJob
 makeBucketJob:
@@ -533,7 +538,8 @@ metrics:
     # for node metrics
     relabelConfigs: {}
     # for cluster metrics
-    relabelConfigsCluster: {}
+    relabelConfigsCluster:
+      {}
       # metricRelabelings:
       #   - regex: (server|pod)
       #     action: labeldrop

--- a/examples/minio/README.md
+++ b/examples/minio/README.md
@@ -17,3 +17,5 @@
 ```shell
     kubectl apply -f  examples/minio/componentplan.yaml
 ```
+
+> Default username and password is `admin/Passw0rd!`

--- a/examples/minio/componentplan.yaml
+++ b/examples/minio/componentplan.yaml
@@ -10,3 +10,7 @@ spec:
   component:
     name: kubebb.minio
     namespace: kubebb-system
+  override:
+    set:
+      - rootUser=admin
+      - rootPassword=Passw0rd!


### PR DESCRIPTION
This pr contains a few changes:

1. update example for minio to set a default user/pass
2. update default bucket to `kubebb` instead of `bestchains`
3. disable `maintainer` check in chart testing