### PR TITLE
Fix: Update kubebb/resource-viewer version in values.yaml

### DIFF
--- a/charts/u4a-component/values.yaml
+++ b/charts/u4a-component/values.yaml
@@ -118,7 +118,7 @@ k8s:
 # Install if it's host cluster
 resourceView:
   enabled: true
-  image: kubebb/resource-viewer:v0.2.0-20221024
+  image: kubebb/resource-viewer:v0.2.0
 
 addon-component:
   enabled: true

--- a/examples/u4a-component/componentplan.yaml
+++ b/examples/u4a-component/componentplan.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   approved: true
   name: u4a-component
-  version: 0.1.11
+  version: 0.2.0
   wait: true
   override:
     valuesFrom:


### PR DESCRIPTION
Fix: Update kubebb/resource-viewer images's version in values.yaml, the correct version is `image: kubebb/resource-viewer:v0.2.0`

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubebb/core/blob/main/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer
