### PR TITLE
Fix wrong args of cert-manager

### DIFF
--- a/charts/cluster-component/Chart.yaml
+++ b/charts/cluster-component/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cluster-component/charts/cert-manager/templates/cert-manager.yaml
+++ b/charts/cluster-component/charts/cert-manager/templates/cert-manager.yaml
@@ -966,7 +966,6 @@ spec:
           args:
           - --v=2
           - --leader-election-namespace={{ .Release.Namespace }}
-          - --enable-certificate-owner-ref=true
           env:
           - name: POD_NAMESPACE
             valueFrom:
@@ -1027,6 +1026,7 @@ spec:
           - --v=2
           - --cluster-resource-namespace=$(POD_NAMESPACE)
           - --leader-election-namespace={{ .Release.Namespace }}
+          - --enable-certificate-owner-ref=true
           ports:
           - containerPort: 9402
             name: http-metrics


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubebb/core/blob/main/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer

`--enable-certificate-owner-ref` is an arg for cert-manager controller, not for cert-manager-cainjector

> https://cert-manager.io/docs/cli/controller/
> https://cert-manager.io/docs/cli/cainjector/