### PR TITLE
replace the redis image to compatible with arm64 and amd64

### DIFF
--- a/charts/u4a-component/values.yaml
+++ b/charts/u4a-component/values.yaml
@@ -96,7 +96,7 @@ oidcServer:
 bffServer:
   enabled: true
   image: kubebb/bff-server:v0.2.0-20231204
-  sessionImage: kubebb/redis:5.0.1-alpine3.8
+  sessionImage: redis:5.0.1-alpine3.8
   host: *bffHost
   connectorId: k8scrd
   clientId: *clientId


### PR DESCRIPTION
replace the image kubebb/redis:5.0.1-alpine3.8 with redis:5.0.1-alpine3.8 to compatible with arm64 and amd64

see issue [https://github.com/kubebb/components/issues/172](https://github.com/kubebb/components/issues/172)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubebb/core/blob/main/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
kubebb/redis:5.0.1-alpine3.8 is not work on Arm64, it need compatible with arm64 and amd64.

#### Special notes for your reviewer
The error when install component:

`Warning  FailedPostStartHook  38s (x2 over 72s)  kubelet            Exec lifecycle hook ([/bin/sh -c redis-cli config set requirepass $PASSWORD]) for Container "redis" in Pod "bff-server-session-redis-66d85f5dbd-dp7ht_u4a-system(5535e4d1-713d-4ef4-bd30-0417e83c88cb)" failed - error: command '/bin/sh -c redis-cli config set requirepass $PASSWORD' exited with 1: Could not connect to Redis at 127.0.0.1:6379: Connection refused`